### PR TITLE
Add buildInput argument to buildDunePackage to template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,10 @@
             duneVersion = "3";
             src = sources.ocaml;
 
+            buildInputs = [
+                # Ocaml package dependencies needed to build go here.
+            ];
+
             strictDeps = true;
 
             preBuild = ''


### PR DESCRIPTION
This confused me when getting started and trying to add opam dependencies, so I explicitly added it to the template that is intended to guide new users. 